### PR TITLE
More CDI role checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,17 +90,20 @@
 			<version>${version.junit}</version>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>${version.guava}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.primefaces</groupId>
 			<artifactId>primefaces</artifactId>
@@ -291,7 +294,7 @@
 				</configuration>
 			</plugin>
 		</plugins>
-		
+
 		<testResources>
 			<!-- see http://arquillian.org/guides/functional_testing_using_graphene/ -->
 			<testResource>

--- a/src/main/java/org/dhbw/mosbach/ai/tickets/beans/TicketCustomerBean.java
+++ b/src/main/java/org/dhbw/mosbach/ai/tickets/beans/TicketCustomerBean.java
@@ -1,12 +1,14 @@
 package org.dhbw.mosbach.ai.tickets.beans;
 
-import com.fasterxml.jackson.databind.util.CompactStringObjectMap;
 import com.google.common.collect.ImmutableList;
 import org.dhbw.mosbach.ai.tickets.database.EntryDAO;
 import org.dhbw.mosbach.ai.tickets.database.TicketDAO;
 import org.dhbw.mosbach.ai.tickets.model.Entry;
+import org.dhbw.mosbach.ai.tickets.model.Roles;
 import org.dhbw.mosbach.ai.tickets.model.Ticket;
+import org.dhbw.mosbach.ai.tickets.security.CDIRoleCheck;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.application.FacesMessage;
 import javax.inject.Inject;
@@ -17,6 +19,8 @@ import java.util.stream.Collectors;
 
 @Named
 @SessionScoped
+@CDIRoleCheck
+@RolesAllowed(value = { Roles.ADMIN, Roles.CUSTOMER})
 public class TicketCustomerBean extends AbstractBean {
 
     @Inject

--- a/src/main/java/org/dhbw/mosbach/ai/tickets/beans/TicketEditorBean.java
+++ b/src/main/java/org/dhbw/mosbach/ai/tickets/beans/TicketEditorBean.java
@@ -4,8 +4,11 @@ import com.google.common.collect.ImmutableList;
 import org.dhbw.mosbach.ai.tickets.database.EntryDAO;
 import org.dhbw.mosbach.ai.tickets.database.TicketDAO;
 import org.dhbw.mosbach.ai.tickets.model.Entry;
+import org.dhbw.mosbach.ai.tickets.model.Roles;
 import org.dhbw.mosbach.ai.tickets.model.Ticket;
+import org.dhbw.mosbach.ai.tickets.security.CDIRoleCheck;
 
+import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.application.FacesMessage;
 import javax.inject.Inject;
@@ -16,6 +19,8 @@ import java.util.stream.Collectors;
 
 @Named
 @SessionScoped
+@CDIRoleCheck
+@RolesAllowed(value = { Roles.ADMIN, Roles.EDITOR})
 public class TicketEditorBean extends AbstractBean {
 
     @Inject
@@ -164,7 +169,4 @@ public class TicketEditorBean extends AbstractBean {
         currentTicket.setStatusToOpen();
         saveTicket(currentTicket);
     }
-
-
-
 }

--- a/src/main/java/org/dhbw/mosbach/ai/tickets/beans/UserBean.java
+++ b/src/main/java/org/dhbw/mosbach/ai/tickets/beans/UserBean.java
@@ -72,8 +72,6 @@ public class    UserBean extends AbstractBean {
         }
     }
 
-
-
     private Role parseRoles(String role){
 
         for (Role roleFromDatabase : roles) {
@@ -178,5 +176,4 @@ public class    UserBean extends AbstractBean {
 
         return loginIds.contains(loginId);
     }
-
 }

--- a/src/main/java/org/dhbw/mosbach/ai/tickets/beans/UserBean.java
+++ b/src/main/java/org/dhbw/mosbach/ai/tickets/beans/UserBean.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 @Named("userBean")
 @SessionScoped
-public class    UserBean extends AbstractBean {
+public class UserBean extends AbstractBean {
     private static final long serialVersionUID = -7105806000082771152L;
 
     @Inject

--- a/src/main/java/org/dhbw/mosbach/ai/tickets/database/BaseDAO.java
+++ b/src/main/java/org/dhbw/mosbach/ai/tickets/database/BaseDAO.java
@@ -1,7 +1,6 @@
 package org.dhbw.mosbach.ai.tickets.database;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/org/dhbw/mosbach/ai/tickets/database/UserDAO.java
+++ b/src/main/java/org/dhbw/mosbach/ai/tickets/database/UserDAO.java
@@ -3,12 +3,10 @@ package org.dhbw.mosbach.ai.tickets.database;
 import org.dhbw.mosbach.ai.tickets.model.Role;
 import org.dhbw.mosbach.ai.tickets.model.Roles;
 import org.dhbw.mosbach.ai.tickets.model.User;
-import org.dhbw.mosbach.ai.tickets.security.CDIRoleCheck;
 import org.jboss.security.Base64Encoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.Dependent;
 import javax.inject.Named;
@@ -20,8 +18,6 @@ import java.util.List;
 
 @Named("userDAO")
 @Dependent
-@CDIRoleCheck
-@RolesAllowed(value = { Roles.ADMIN })
 public class UserDAO extends BaseDAO<User, Long> {
     private static final long serialVersionUID = -6308185751264138344L;
     private static final Logger logger = LoggerFactory.getLogger(UserDAO.class);
@@ -30,6 +26,7 @@ public class UserDAO extends BaseDAO<User, Long> {
         super();
     }
 
+    @RolesAllowed(value = { Roles.ADMIN })
     private MessageDigest getMessageDigest() {
         try {
             return MessageDigest.getInstance("SHA-256");
@@ -39,6 +36,7 @@ public class UserDAO extends BaseDAO<User, Long> {
         }
     }
 
+    @RolesAllowed(value = { Roles.ADMIN })
     public void changePassword(User user, String password) {
         try {
             user.setPassword(Base64Encoder.encode(getMessageDigest().digest(password.getBytes())));
@@ -48,7 +46,6 @@ public class UserDAO extends BaseDAO<User, Long> {
     }
 
     @Override
-    @PermitAll
     public User findByUnique(String fieldName, Object key) {
         return super.findByUnique(fieldName, key);
     }
@@ -65,22 +62,22 @@ public class UserDAO extends BaseDAO<User, Long> {
         return Collections.emptyList();
     }
 
+    @RolesAllowed(value = { Roles.ADMIN })
     public List<Role> getRoles() {
-
         final String query = String.format("FROM %s", Role.class.getName());
 
         return em.createQuery(query, Role.class).getResultList();
     }
 
+    @RolesAllowed(value = { Roles.ADMIN })
     public List<String> getCompanies() {
-
         final String query = String.format("SELECT DISTINCT u.company FROM %s u", User.class.getName());
 
         return em.createQuery(query, String.class).getResultList();
     }
 
+    @RolesAllowed(value = { Roles.ADMIN })
     public List<String> getLoginIds() {
-
         final String query = String.format("SELECT u.login_id FROM %s u", User.class.getName());
 
         return em.createQuery(query, String.class).getResultList();

--- a/src/main/java/org/dhbw/mosbach/ai/tickets/database/UserDAO.java
+++ b/src/main/java/org/dhbw/mosbach/ai/tickets/database/UserDAO.java
@@ -3,6 +3,7 @@ package org.dhbw.mosbach.ai.tickets.database;
 import org.dhbw.mosbach.ai.tickets.model.Role;
 import org.dhbw.mosbach.ai.tickets.model.Roles;
 import org.dhbw.mosbach.ai.tickets.model.User;
+import org.dhbw.mosbach.ai.tickets.security.CDIRoleCheck;
 import org.jboss.security.Base64Encoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,8 @@ import java.util.List;
 
 @Named("userDAO")
 @Dependent
+@CDIRoleCheck
+@RolesAllowed(value = { Roles.ADMIN })
 public class UserDAO extends BaseDAO<User, Long> {
     private static final long serialVersionUID = -6308185751264138344L;
     private static final Logger logger = LoggerFactory.getLogger(UserDAO.class);
@@ -36,7 +39,6 @@ public class UserDAO extends BaseDAO<User, Long> {
         }
     }
 
-    @RolesAllowed(value = { Roles.ADMIN })
     public void changePassword(User user, String password) {
         try {
             user.setPassword(Base64Encoder.encode(getMessageDigest().digest(password.getBytes())));
@@ -63,7 +65,6 @@ public class UserDAO extends BaseDAO<User, Long> {
         return Collections.emptyList();
     }
 
-    @RolesAllowed(value = { Roles.ADMIN })
     public List<Role> getRoles() {
 
         final String query = String.format("FROM %s", Role.class.getName());
@@ -71,7 +72,6 @@ public class UserDAO extends BaseDAO<User, Long> {
         return em.createQuery(query, Role.class).getResultList();
     }
 
-    @RolesAllowed(value = { Roles.ADMIN })
     public List<String> getCompanies() {
 
         final String query = String.format("SELECT DISTINCT u.company FROM %s u", User.class.getName());
@@ -85,5 +85,4 @@ public class UserDAO extends BaseDAO<User, Long> {
 
         return em.createQuery(query, String.class).getResultList();
     }
-
 }


### PR DESCRIPTION
check roles for editor-, customer- and admin-specific stuff

unrestircted users can't fetch critical information from database, e.g. only admin can obtain user data like roles